### PR TITLE
Solved phasing at high speeds and at low framerates

### DIFF
--- a/Assets/SuperCharacterController/Core/SuperCharacterController.cs
+++ b/Assets/SuperCharacterController/Core/SuperCharacterController.cs
@@ -370,7 +370,7 @@ public class SuperCharacterController : MonoBehaviour
 
         collisionData.Clear();
 
-		bool contact = false;
+	bool contact = false;
 					
         foreach (var sphere in spheres)
         {


### PR DESCRIPTION
I solved the phasing issue when having the character moving at long distances per frame (both at high speeds and at big time deltas).
Previously the character would have warped through the colliders as there was no collision test between the start position of the character and it's calculated final position.

I would appreciate if @IronWarrior could take a look at it and give an opinion on my solution
