### PR TITLE
Adding fix for SphereCollider with a center != 0

### DIFF
--- a/Assets/SuperCharacterController/Core/SuperCollider.cs
+++ b/Assets/SuperCharacterController/Core/SuperCollider.cs
@@ -52,11 +52,11 @@ public static class SuperCollider {
     {
         Vector3 p;
 
-        p = to - collider.transform.position;
+        p = to - (collider.transform.position + collider.center);
         p.Normalize();
 
         p *= collider.radius * collider.transform.localScale.x;
-        p += collider.transform.position;
+        p += collider.transform.position + collider.center;
 
         return p;
     }


### PR DESCRIPTION
Not sure if the center property has been introduced recently.
If this is the case, then this may be incompatible with older versions of unity.