### PR TITLE
Fixed incorrect pushback position when mesh has no ClosestPointOnSurface

### DIFF
--- a/Assets/SuperCharacterController/Core/SuperCharacterController.cs
+++ b/Assets/SuperCharacterController/Core/SuperCharacterController.cs
@@ -342,13 +342,22 @@ public class SuperCharacterController : MonoBehaviour
             foreach (Collider col in Physics.OverlapSphere((SpherePosition(sphere)), radius, Walkable, triggerInteraction))
             {
                 Vector3 position = SpherePosition(sphere);
-                Vector3 contactPoint = SuperCollider.ClosestPointOnSurface(col, position, radius);
+                Vector3 contactPoint = Vector3.zero;
 
+                try
+                {
+                    contactPoint = SuperCollider.ClosestPointOnSurface(col, position, radius);
+                }
+                catch (SuperCollider.ClosestPointOnSurfaceNotImplementedException ex)
+                {
+                    Debug.Log(ex.Message);
+                    return;
+                }
+                 
                 if (debugPushbackMesssages)
                     DebugDraw.DrawMarker(contactPoint, 2.0f, Color.cyan, 0.0f, false);
 
                 Vector3 v = contactPoint - position;
-
                 if (v != Vector3.zero)
                 {
                     // Cache the collider's layer so that we can cast against it

--- a/Assets/SuperCharacterController/Core/SuperCharacterController.cs
+++ b/Assets/SuperCharacterController/Core/SuperCharacterController.cs
@@ -342,21 +342,17 @@ public class SuperCharacterController : MonoBehaviour
             foreach (Collider col in Physics.OverlapSphere((SpherePosition(sphere)), radius, Walkable, triggerInteraction))
             {
                 Vector3 position = SpherePosition(sphere);
-                Vector3 contactPoint = Vector3.zero;
-
-                try
+                Vector3 contactPoint;
+                bool contactPointSuccess = SuperCollider.ClosestPointOnSurface(col, position, radius, out contactPoint);
+                
+                if (!contactPointSuccess)
                 {
-                    contactPoint = SuperCollider.ClosestPointOnSurface(col, position, radius);
-                }
-                catch (SuperCollider.ClosestPointOnSurfaceNotImplementedException ex)
-                {
-                    Debug.Log(ex.Message);
                     return;
                 }
-                 
+                                            
                 if (debugPushbackMesssages)
                     DebugDraw.DrawMarker(contactPoint, 2.0f, Color.cyan, 0.0f, false);
-
+                    
                 Vector3 v = contactPoint - position;
                 if (v != Vector3.zero)
                 {

--- a/Assets/SuperCharacterController/Core/SuperCollider.cs
+++ b/Assets/SuperCharacterController/Core/SuperCollider.cs
@@ -44,12 +44,10 @@ public static class SuperCollider {
         {
             return SuperCollider.ClosestPointOnSurface((TerrainCollider)collider, to, radius, false);
         }
-
-        Debug.LogError(string.Format("{0} does not have an implementation for ClosestPointOnSurface", collider.GetType()));
-
-        return Vector3.zero;
+                
+        throw new ClosestPointOnSurfaceNotImplementedException(collider);
     }
-
+    
     public static Vector3 ClosestPointOnSurface(SphereCollider collider, Vector3 to)
     {
         Vector3 p;
@@ -268,4 +266,22 @@ public static class SuperCollider {
 
         return collider.transform.TransformPoint(shortestPoint);
     }
+
+    public class SuperColliderException : System.Exception
+    {
+        public SuperColliderException(string message) : base(message) { }
+    }
+
+    public class ClosestPointOnSurfaceNotImplementedException : SuperColliderException
+    {
+        Collider Collider;
+        public ClosestPointOnSurfaceNotImplementedException(Collider collider) : base(HumanReadable(collider)) {
+            Collider = collider;
+        }
+        private static string HumanReadable(Collider collider)
+        {
+            return string.Format("{0} does not have an implementation for ClosestPointOnSurface; GameObject.Name='{1}'", collider.GetType(), collider.gameObject.name);
+        }
+    }
+
 }

--- a/Assets/SuperCharacterController/Core/SuperCollider.cs
+++ b/Assets/SuperCharacterController/Core/SuperCollider.cs
@@ -3,19 +3,22 @@ using System.Collections;
 
 public static class SuperCollider {
 
-    public static Vector3 ClosestPointOnSurface(Collider collider, Vector3 to, float radius)
+    public static bool ClosestPointOnSurface(Collider collider, Vector3 to, float radius, out Vector3 closestPointOnSurface)
     {
         if (collider is BoxCollider)
         {
-            return SuperCollider.ClosestPointOnSurface((BoxCollider)collider, to);
+            closestPointOnSurface = SuperCollider.ClosestPointOnSurface((BoxCollider)collider, to);
+            return true;
         }
         else if (collider is SphereCollider)
         {
-            return SuperCollider.ClosestPointOnSurface((SphereCollider)collider, to);
+            closestPointOnSurface = SuperCollider.ClosestPointOnSurface((SphereCollider)collider, to);
+            return true;
         }
         else if (collider is CapsuleCollider)
         {
-            return SuperCollider.ClosestPointOnSurface((CapsuleCollider)collider, to);
+            closestPointOnSurface = SuperCollider.ClosestPointOnSurface((CapsuleCollider)collider, to);
+            return true;
         }
         else if (collider is MeshCollider)
         {
@@ -23,29 +26,35 @@ public static class SuperCollider {
 
             if (rpgMesh != null)
             {
-                return rpgMesh.ClosestPointOn(to, radius, false, false);
+                closestPointOnSurface = rpgMesh.ClosestPointOn(to, radius, false, false);
+                return true;
             }
 
             BSPTree bsp = collider.GetComponent<BSPTree>();
 
             if (bsp != null)
             {
-                return bsp.ClosestPointOn(to, radius);
+                closestPointOnSurface = bsp.ClosestPointOn(to, radius);
+                return true;
             }
 
             BruteForceMesh bfm = collider.GetComponent<BruteForceMesh>();
 
             if (bfm != null)
             {
-                return bfm.ClosestPointOn(to);
+                closestPointOnSurface = bfm.ClosestPointOn(to);
+                return true;
             }
         }
         else if (collider is TerrainCollider)
         {
-            return SuperCollider.ClosestPointOnSurface((TerrainCollider)collider, to, radius, false);
+            closestPointOnSurface = SuperCollider.ClosestPointOnSurface((TerrainCollider)collider, to, radius, false);
+            return true;
         }
-                
-        throw new ClosestPointOnSurfaceNotImplementedException(collider);
+
+        Debug.LogError(string.Format("{0} does not have an implementation for ClosestPointOnSurface; GameObject.Name='{1}'", collider.GetType(), collider.gameObject.name));
+        closestPointOnSurface = Vector3.zero;
+        return false;
     }
     
     public static Vector3 ClosestPointOnSurface(SphereCollider collider, Vector3 to)
@@ -265,23 +274,6 @@ public static class SuperCollider {
         }
 
         return collider.transform.TransformPoint(shortestPoint);
-    }
-
-    public class SuperColliderException : System.Exception
-    {
-        public SuperColliderException(string message) : base(message) { }
-    }
-
-    public class ClosestPointOnSurfaceNotImplementedException : SuperColliderException
-    {
-        Collider Collider;
-        public ClosestPointOnSurfaceNotImplementedException(Collider collider) : base(HumanReadable(collider)) {
-            Collider = collider;
-        }
-        private static string HumanReadable(Collider collider)
-        {
-            return string.Format("{0} does not have an implementation for ClosestPointOnSurface; GameObject.Name='{1}'", collider.GetType(), collider.gameObject.name);
-        }
     }
 
 }


### PR DESCRIPTION
Fixed character 'disappearing' when touching a mesh without a ClosestPointOnSurface method implemented. This was introduced with commit _0c50765cc80bd523652aa59c43c7f4bdc1a0d1d7_ "fix for error where the controller would not properly be pushed back at position 0,0,0.".