### PR TITLE
Fixed camera issue with fixed time steps

### DIFF
--- a/Assets/SuperCharacterController/Scripts/PlayerMachine.cs
+++ b/Assets/SuperCharacterController/Scripts/PlayerMachine.cs
@@ -46,7 +46,8 @@ public class PlayerMachine : SuperStateMachine {
     protected override void EarlyGlobalSuperUpdate()
     {
 		// Rotate out facing direction horizontally based on mouse input
-        lookDirection = Quaternion.AngleAxis(input.Current.MouseInput.x, controller.up) * lookDirection;
+        // (Taking into account that this method may be called multiple times per frame)
+        lookDirection = Quaternion.AngleAxis(input.Current.MouseInput.x * (controller.deltaTime / Time.deltaTime), controller.up) * lookDirection;
         // Put any code in here you want to run BEFORE the state's update function.
         // This is run regardless of what state you're in
     }


### PR DESCRIPTION
When deltaTime exceeds the fixed time step, SuperUpdate is called multiple times with deltaTime broken up so that none of the calls exceed the fixed time step (avoiding issues like tunnelling). This was implemented into PlayerMachine in 4dcc93dbfba0a0badcd41911cc38c8c185e67933 but EarlyGlobalSuperUpdate() does not take into account the fraction of deltaTime it represents. So for example if there is a horizontal movement of 4 degrees and deltaTime just exceeds the fixed time step, an 8 degree horizontal rotation to look direction would be incorrectly applied. 

This commit fixes the issue by applying only the fraction of rotation that is applicable in each EarlyGlobalSuperUpdate call