### PR TITLE
Added collider null check for nearhit

### DIFF
--- a/Assets/SuperCharacterController/SuperCharacterController/Core/SuperCharacterController.cs
+++ b/Assets/SuperCharacterController/SuperCharacterController/Core/SuperCharacterController.cs
@@ -648,8 +648,13 @@ public class SuperCharacterController : MonoBehaviour
                 // it is connected to at it's base, if there exists any
                 if (Vector3.Angle(nearHit.normal, up) > superColType.StandAngle || nearHit.distance > Tolerance)
                 {
-                    var col = nearHit.collider.gameObject.GetComponent<SuperCollisionType>();
-
+                    SuperCollisionType col = null;
+                
+                    if (nearhit.collider != null)
+                    {
+                        col = nearHit.collider.gameObject.GetComponent<SuperCollisionType>();
+                    }
+                    
                     if (col == null)
                     {
                         col = defaultCollisionType;

--- a/Assets/SuperCharacterController/SuperCharacterController/Core/SuperCharacterController.cs
+++ b/Assets/SuperCharacterController/SuperCharacterController/Core/SuperCharacterController.cs
@@ -650,7 +650,7 @@ public class SuperCharacterController : MonoBehaviour
                 {
                     SuperCollisionType col = null;
                 
-                    if (nearhit.collider != null)
+                    if (nearHit.collider != null)
                     {
                         col = nearHit.collider.gameObject.GetComponent<SuperCollisionType>();
                     }


### PR DESCRIPTION
Added collider null check for nearhit in **SuperCharacterController.cs**

Without this check we get a null reference exception at line 651 if we reach the end or a gap in the map. As a consequence of this _"Debug.LogError("[SuperCharacterComponent]: No ground was found below the player; player has escaped level");"_ never gets called.

![supercharactercontroller bug](https://cloud.githubusercontent.com/assets/8476361/25795893/af6ffa88-33d7-11e7-9ab1-191723276754.png)
